### PR TITLE
Develop

### DIFF
--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -149,6 +149,16 @@ namespace Shadowsocks.View
             }
             Configuration config = controller.GetCurrentConfiguration();
             bool enabled = config.sysProxyMode != (int)ProxyMode.NoModify && config.sysProxyMode != (int)ProxyMode.Direct;
+            string server;
+            if (config.random)
+            {
+                server = config.balanceAlgorithm;
+            }
+            else
+            {
+                int server_current = config.index;
+                server = config.configs[server_current].remarks;
+            }
             bool global = config.sysProxyMode == (int)ProxyMode.Global;
             bool random = config.random;
 
@@ -212,10 +222,51 @@ namespace Shadowsocks.View
                 _notifyIcon.Icon = newIcon;
             }
 
+            /*Balance = 负载均衡
+            OneByOne = 按次序
+            Random = 随机
+            FastDownloadSpeed = 下载速度优先
+            LowLatency = 低延迟优先
+            LowException = 低错误优先
+            SelectedFirst = 选中优先
+            Timer = 定时切换*/
+
+            string strServer = server;
+
+            switch (strServer)
+            {
+                case "OneByOne":
+                    strServer = "负载均衡 : 按次序";
+                    break;
+                case "Random":
+                    strServer = "负载均衡 : 随机";
+                    break;
+                case "FastDownloadSpeed":
+                    strServer = "负载均衡 : 下载速度优先";
+                    break;
+                case "LowLatency":
+                    strServer = "负载均衡 : 低延迟优先";
+                    break;
+                case "LowException":
+                    strServer = "负载均衡 : 低错误优先";
+                    break;
+                case "SelectedFirst":
+                    strServer = "负载均衡 : 选中优先";
+                    break;
+                case "Timer":
+                    strServer = "负载均衡 : 定时切换";
+                    break;
+                default:
+                    strServer = server;
+                    break;
+
+            }
             // we want to show more details but notify icon title is limited to 63 characters
             string text = (enabled ?
                     (global ? I18N.GetString("Global") : I18N.GetString("PAC")) :
                     I18N.GetString("Disable system proxy"))
+                    + "\r\n"
+                    + strServer
                     + "\r\n"
                     + String.Format(I18N.GetString("Running: Port {0}"), config.localPort)  // this feedback is very important because they need to know Shadowsocks is running
                     ;

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -222,44 +222,33 @@ namespace Shadowsocks.View
                 _notifyIcon.Icon = newIcon;
             }
 
-            /*Balance = 负载均衡
-            OneByOne = 按次序
-            Random = 随机
-            FastDownloadSpeed = 下载速度优先
-            LowLatency = 低延迟优先
-            LowException = 低错误优先
-            SelectedFirst = 选中优先
-            Timer = 定时切换*/
-
             string strServer = server;
-
             switch (strServer)
             {
                 case "OneByOne":
-                    strServer = "负载均衡 : 按次序";
+                    strServer = I18N.GetString("Balance") + " : " + I18N.GetString("OneByOne");
                     break;
                 case "Random":
-                    strServer = "负载均衡 : 随机";
+                    strServer = I18N.GetString("Balance") + " : " + I18N.GetString("Random");
                     break;
                 case "FastDownloadSpeed":
-                    strServer = "负载均衡 : 下载速度优先";
+                    strServer = I18N.GetString("Balance") + " : " + I18N.GetString("FastDownloadSpeed");
                     break;
                 case "LowLatency":
-                    strServer = "负载均衡 : 低延迟优先";
+                    strServer = I18N.GetString("Balance") + " : " + I18N.GetString("LowLatency");
                     break;
                 case "LowException":
-                    strServer = "负载均衡 : 低错误优先";
+                    strServer = I18N.GetString("Balance") + " : " + I18N.GetString("LowException");
                     break;
                 case "SelectedFirst":
-                    strServer = "负载均衡 : 选中优先";
+                    strServer = I18N.GetString("Balance") + " : " + I18N.GetString("SelectedFirst");
                     break;
                 case "Timer":
-                    strServer = "负载均衡 : 定时切换";
+                    strServer = I18N.GetString("Balance") + " : " + I18N.GetString("OneByOne");
                     break;
                 default:
                     strServer = server;
                     break;
-
             }
             // we want to show more details but notify icon title is limited to 63 characters
             string text = (enabled ?


### PR DESCRIPTION
1,Bubble shows the current connection server name or load balancing type;
   重新添加气泡显示当前连接服务器名称或者负载均衡类型;
2,fix tranlastions for bubble shows the current connection server name;
   当气泡显示为负载均衡类型时也会自动调用相应的简繁英翻译显示;
3,fix show more details but notify icon title is limited to 63 characters 
  用了反射设定解除了系统栏工具提示的63字符限制;
![Snipaste_2019-05-09_06-03-03](https://user-images.githubusercontent.com/9752596/57382893-5db0ed80-71e0-11e9-852c-81afee7f121d.png)
